### PR TITLE
Fix the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 ### Download and Install from source
 
 ```shell
-$ wget -P ~/Downloads https://github.com/madhav-datt/spell-check/archive/v2.0.zip
-$ unzip ~/Downloads/spell-check-2.0.zip
-$ mv ~/Downloads/spell-check-2.0 ~/Downloads/spell-check
+$ cd -- "$(mktemp -d)"
+$ git clone https://github.com/madhav-datt/spell-check
 $ chmod +x spell-check/install
-$ sudo spell-check/install
+$ pwd | xargs sudo spell-check/install
+$ sudo ln -s /opt/spell-check/src/spellcheck /usr/local/bin/spellcheck
 ```
 
 ### Running spellchecker

--- a/install
+++ b/install
@@ -7,18 +7,14 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #
 
-# Move spell-check to /etc
-cd /etc
-mkdir spell-check
-mv ~/Downloads/spell-check/* /etc/spell-check
-cd /etc/spell-check
+# Move spell-check to /opt
+mkdir /opt/spell-check
+mv $1/spell-check/* /opt/spell-check
+cd /opt/spell-check
 
 # Add permanent aliases for scripts
 cat aliases.txt >> ~/.bash_aliases
 . ~/.bashrc
-
-# Clean downloaded folders
-rm -rf ~/Downloads/spell-check
 
 # Compile C source code
 cd src


### PR DESCRIPTION
The current installer was broken. I fixed it and improved
parts of the installation process:
- we download the files to a temporary directory, which is
cleaned up automatically afterwards
- we install the whole thing to /opt instead of /etc, this way
we respect the FHS
- we create a symlink to spellckeck that's in user's PATH

The script now clones master, as the v2 release depended on the old script.